### PR TITLE
Downgrade Microsoft.CodeAnalysis.CSharp to 4.5.0

### DIFF
--- a/AltV.Community.MValueAdapters.Generators/AltV.Community.MValueAdapters.Generators.csproj
+++ b/AltV.Community.MValueAdapters.Generators/AltV.Community.MValueAdapters.Generators.csproj
@@ -34,7 +34,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0">
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>


### PR DESCRIPTION
I don't know why, maybe something I initially wrote in the generator logic, but I always had issues with 4.8.0 (either compile-time or unexplainable things xd). Maybe it fixes the empty RegisterAdapters from @kaiwoknats