### PR TITLE
New converters

### DIFF
--- a/AltV.Community.MValueAdapters.Generators/Constants/Templates.cs
+++ b/AltV.Community.MValueAdapters.Generators/Constants/Templates.cs
@@ -12,7 +12,7 @@ namespace AltV.Community.MValueAdapters.Generators;
 using AltV.Net;
 using AltV.Net.Elements.Args;
 using AltV.Net.Shared;
-using {0};
+{0}
 
 public sealed class {1}Adapter : IMValueAdapter<{1}>
 {{

--- a/AltV.Community.MValueAdapters.Generators/Converters/BaseConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/BaseConverter.cs
@@ -1,10 +1,12 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using AltV.Community.MValueAdapters.Generators.Models;
 
 namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal abstract class BaseConverter : ITypeConverter
 {
+    public virtual string[] AdditionalUsings() => Array.Empty<string>();
     protected abstract void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo);
     protected abstract void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo);
     protected abstract void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo);

--- a/AltV.Community.MValueAdapters.Generators/Converters/BaseConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/BaseConverter.cs
@@ -5,12 +5,12 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal abstract class BaseConverter : ITypeConverter
 {
-    protected abstract void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo);
-    protected abstract void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo);
-    protected abstract void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo);
-    protected abstract void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo);
+    protected abstract void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo);
+    protected abstract void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo);
+    protected abstract void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo);
+    protected abstract void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo);
 
-    public void WriteItem(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    public void WriteItem(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         if (propertyInfo.Nullable)
         {
@@ -19,7 +19,7 @@ internal abstract class BaseConverter : ITypeConverter
         }
 
         stringBuilder.AppendLine(indentation, $"writer.Name(\"{propertyInfo.CustomName ?? propertyInfo.Name}\");");
-        GenerateItemWriteCode(stringBuilder, ref indentation, propertyInfo);
+        GenerateItemWriteCode(stringBuilder, ref indentation, classInfo, propertyInfo);
 
         if (propertyInfo.Nullable)
         {
@@ -27,18 +27,18 @@ internal abstract class BaseConverter : ITypeConverter
         }
     }
 
-    public void ReadItem(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    public void ReadItem(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation++, $"case \"{propertyInfo.CustomName ?? propertyInfo.Name}\":");
-        GenerateItemReadCode(stringBuilder, ref indentation, propertyInfo);
+        GenerateItemReadCode(stringBuilder, ref indentation, classInfo, propertyInfo);
         stringBuilder.AppendLine(indentation--, "continue;");
     }
 
-    public void WriteCollection(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    public void WriteCollection(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         if (propertyInfo.PropertyType == PropertyType.Default)
         {
-            WriteItem(stringBuilder, ref indentation, propertyInfo);
+            WriteItem(stringBuilder, ref indentation, classInfo, propertyInfo);
             return;
         }
 
@@ -59,7 +59,7 @@ internal abstract class BaseConverter : ITypeConverter
             stringBuilder.AppendLine(indentation++, "{");
         }
 
-        GenerateCollectionWriteCode(stringBuilder, ref indentation, propertyInfo);
+        GenerateCollectionWriteCode(stringBuilder, ref indentation, classInfo, propertyInfo);
 
         if (propertyInfo.NullableCollection)
         {
@@ -75,11 +75,11 @@ internal abstract class BaseConverter : ITypeConverter
         }
     }
 
-    public void ReadCollection(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    public void ReadCollection(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         if (propertyInfo.PropertyType == PropertyType.Default)
         {
-            WriteItem(stringBuilder, ref indentation, propertyInfo);
+            WriteItem(stringBuilder, ref indentation, classInfo, propertyInfo);
             return;
         }
 
@@ -88,7 +88,7 @@ internal abstract class BaseConverter : ITypeConverter
         stringBuilder.AppendLine(indentation, "reader.BeginArray();");
         stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
         stringBuilder.AppendLine(indentation++, "{");
-        GenerateCollectionReadCode(stringBuilder, ref indentation, propertyInfo);
+        GenerateCollectionReadCode(stringBuilder, ref indentation, classInfo, propertyInfo);
         stringBuilder.AppendLine(--indentation, "}");
         stringBuilder.AppendLine(indentation, "reader.EndArray();");
 

--- a/AltV.Community.MValueAdapters.Generators/Converters/ITypeConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/ITypeConverter.cs
@@ -5,6 +5,7 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal interface ITypeConverter
 {
+    public abstract string[] AdditionalUsings();
     public abstract void WriteItem(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo);
     public abstract void ReadItem(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo);
     public void WriteCollection(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo);

--- a/AltV.Community.MValueAdapters.Generators/Converters/ITypeConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/ITypeConverter.cs
@@ -5,8 +5,8 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal interface ITypeConverter
 {
-    public abstract void WriteItem(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo);
-    public abstract void ReadItem(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo);
-    public void WriteCollection(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo);
-    public void ReadCollection(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo);
+    public abstract void WriteItem(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo);
+    public abstract void ReadItem(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo);
+    public void WriteCollection(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo);
+    public void ReadCollection(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo);
 }

--- a/AltV.Community.MValueAdapters.Generators/Converters/Numerics/ByteConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Numerics/ByteConverter.cs
@@ -5,22 +5,22 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal class ByteConverter : BaseConverter
 {
-    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"writer.Value((int)value.{propertyInfo.Name});");
     }
 
-    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = (byte)reader.NextInt();");
     }
 
-    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, "writer.Value((int)item);");
     }
 
-    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add((byte)reader.NextInt());");
     }

--- a/AltV.Community.MValueAdapters.Generators/Converters/Numerics/DecimalConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Numerics/DecimalConverter.cs
@@ -5,22 +5,22 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal class DecimalConverter : BaseConverter
 {
-    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"writer.Value((double)value.{propertyInfo.Name});");
     }
 
-    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = (decimal)reader.NextDouble();");
     }
 
-    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, "writer.Value((double)item);");
     }
 
-    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add((decimal)reader.NextDouble());");
     }

--- a/AltV.Community.MValueAdapters.Generators/Converters/Numerics/DoubleConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Numerics/DoubleConverter.cs
@@ -5,22 +5,22 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal class DoubleConverter : BaseConverter
 {
-    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"writer.Value((double)value.{propertyInfo.Name});");
     }
 
-    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = (double)reader.NextDouble();");
     }
 
-    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, "writer.Value((double)item);");
     }
 
-    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add((double)reader.NextDouble());");
     }

--- a/AltV.Community.MValueAdapters.Generators/Converters/Numerics/FloatConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Numerics/FloatConverter.cs
@@ -5,22 +5,22 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal class FloatConverter : BaseConverter
 {
-    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"writer.Value((double)value.{propertyInfo.Name});");
     }
 
-    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = (float)reader.NextDouble();");
     }
 
-    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, "writer.Value((double)item);");
     }
 
-    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add((float)reader.NextDouble());");
     }

--- a/AltV.Community.MValueAdapters.Generators/Converters/Numerics/IntConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Numerics/IntConverter.cs
@@ -5,22 +5,22 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal class IntConverter : BaseConverter
 {
-    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"writer.Value((int)value.{propertyInfo.Name});");
     }
 
-    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = (int)reader.NextInt();");
     }
 
-    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, "writer.Value((int)item);");
     }
 
-    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add((int)reader.NextInt());");
     }

--- a/AltV.Community.MValueAdapters.Generators/Converters/Numerics/LongConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Numerics/LongConverter.cs
@@ -5,22 +5,22 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal class LongConverter : BaseConverter
 {
-    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"writer.Value((long)value.{propertyInfo.Name});");
     }
 
-    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = (long)reader.NextLong();");
     }
 
-    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, "writer.Value((long)item);");
     }
 
-    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add((long)reader.NextLong());");
     }

--- a/AltV.Community.MValueAdapters.Generators/Converters/Numerics/SByteConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Numerics/SByteConverter.cs
@@ -5,22 +5,22 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal class SByteConverter : BaseConverter
 {
-    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"writer.Value((int)value.{propertyInfo.Name});");
     }
 
-    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = (sbyte)reader.NextInt();");
     }
 
-    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, "writer.Value((int)item);");
     }
 
-    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add((sbyte)reader.NextInt());");
     }

--- a/AltV.Community.MValueAdapters.Generators/Converters/Numerics/ShortConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Numerics/ShortConverter.cs
@@ -5,22 +5,22 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal class ShortConverter : BaseConverter
 {
-    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"writer.Value((int)value.{propertyInfo.Name});");
     }
 
-    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = (short)reader.NextInt();");
     }
 
-    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, "writer.Value((int)item);");
     }
 
-    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add((short)reader.NextInt());");
     }

--- a/AltV.Community.MValueAdapters.Generators/Converters/Numerics/UIntConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Numerics/UIntConverter.cs
@@ -5,22 +5,22 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal class UIntConverter : BaseConverter
 {
-    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"writer.Value((uint)value.{propertyInfo.Name});");
     }
 
-    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = (uint)reader.NextUInt();");
     }
 
-    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, "writer.Value((uint)item);");
     }
 
-    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add((uint)reader.NextUInt());");
     }

--- a/AltV.Community.MValueAdapters.Generators/Converters/Numerics/ULongConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Numerics/ULongConverter.cs
@@ -5,22 +5,22 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal class ULongConverter : BaseConverter
 {
-    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"writer.Value((ulong)value.{propertyInfo.Name});");
     }
 
-    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = (ulong)reader.NextULong();");
     }
 
-    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, "writer.Value((ulong)item);");
     }
 
-    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add((ulong)reader.NextULong());");
     }

--- a/AltV.Community.MValueAdapters.Generators/Converters/Numerics/UShortConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Numerics/UShortConverter.cs
@@ -5,22 +5,22 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal class UShortConverter : BaseConverter
 {
-    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"writer.Value((int)value.{propertyInfo.Name});");
     }
 
-    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = (ushort)reader.NextInt();");
     }
 
-    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, "writer.Value((int)item);");
     }
 
-    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add((ushort)reader.NextInt());");
     }

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/BoolConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/BoolConverter.cs
@@ -5,22 +5,22 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal class BoolConverter : BaseConverter
 {
-    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"writer.Value((bool)value.{propertyInfo.Name});");
     }
 
-    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = (bool)reader.NextBool();");
     }
 
-    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, "writer.Value((bool)item);");
     }
 
-    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add((bool)reader.NextBool());");
     }

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/ByAdapterConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/ByAdapterConverter.cs
@@ -7,23 +7,23 @@ internal class ByAdapterConverter(string typeName) : BaseConverter()
 {
     private readonly string _typeName = typeName;
 
-    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"new {_typeName}Adapter().ToMValue(value.{propertyInfo.Name}, writer);");
     }
 
-    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = new {_typeName}Adapter().FromMValue(reader);");
     }
 
-    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         // TODO: improve performance by reuse adapter instance
         stringBuilder.AppendLine(indentation, $"new {_typeName}Adapter().ToMValue(value.{propertyInfo.Name}, writer);");
     }
 
-    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         // TODO: improve performance by reuse adapter instance
         stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add(new {_typeName}Adapter().FromMValue(reader));");

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/ClothConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/ClothConverter.cs
@@ -1,0 +1,95 @@
+using System.Text;
+using AltV.Community.MValueAdapters.Generators.Models;
+using AltV.Community.MValueAdapters.Generators.Utils;
+
+namespace AltV.Community.MValueAdapters.Generators.Converters;
+
+internal class ClothConverter : BaseConverter
+{
+    public override string[] AdditionalUsings() => ["AltV.Net.Data"];
+
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Drawable", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((uint)value.{propertyInfo.Name}.Drawable);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Texture", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((uint)value.{propertyInfo.Name}.Texture);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Palette", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((uint)value.{propertyInfo.Name}.Palette);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(4);
+
+        stringBuilder.AppendLine(indentation, $"ushort {tmpNames[0]} = 0;");
+        stringBuilder.AppendLine(indentation, $"byte {tmpNames[1]} = 0, {tmpNames[2]} = 0;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[3]} = reader.NextName();");
+        stringBuilder.AppendLine(indentation, $"switch ({tmpNames[3]})");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Drawable", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (ushort)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Texture", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Palette", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = new Cloth({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]});");
+    }
+
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Drawable", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((uint)item.Drawable);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Texture", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((uint)item.Texture);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Palette", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((uint)item.Palette);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(5);
+
+        stringBuilder.AppendLine(indentation, $"ushort {tmpNames[0]} = 0;");
+        stringBuilder.AppendLine(indentation, $"byte {tmpNames[1]} = 0, {tmpNames[2]} = 0;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[3]} = reader.NextName();");
+        stringBuilder.AppendLine(indentation, $"switch ({tmpNames[3]})");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Drawable", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (ushort)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Texture", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Palette", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[4]} = new Cloth({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]});");
+        stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add({tmpNames[4]});");
+    }
+}

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/DlcClothConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/DlcClothConverter.cs
@@ -1,0 +1,104 @@
+using System.Text;
+using AltV.Community.MValueAdapters.Generators.Models;
+using AltV.Community.MValueAdapters.Generators.Utils;
+
+namespace AltV.Community.MValueAdapters.Generators.Converters;
+
+internal class DlcClothConverter : BaseConverter
+{
+    public override string[] AdditionalUsings() => ["AltV.Net.Data"];
+
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Drawable", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((int)value.{propertyInfo.Name}.Drawable);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Texture", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((int)value.{propertyInfo.Name}.Texture);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Palette", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((int)value.{propertyInfo.Name}.Palette);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Dlc", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((uint)value.{propertyInfo.Name}.Dlc);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(4);
+
+        stringBuilder.AppendLine(indentation, $"ushort {tmpNames[0]} = 0;");
+        stringBuilder.AppendLine(indentation, $"byte {tmpNames[1]} = 0, {tmpNames[2]} = 0;");
+        stringBuilder.AppendLine(indentation, $"uint {tmpNames[3]} = 0;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"switch (reader.NextName())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Drawable", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (ushort)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Texture", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Palette", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Dlc", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[3]} = reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = new DlcCloth({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]}, {tmpNames[3]});");
+    }
+
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Drawable", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((uint)item.Drawable);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Texture", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((uint)item.Texture);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Palette", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((uint)item.Palette);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Dlc", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((uint)item.Dlc);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(4);
+
+        stringBuilder.AppendLine(indentation, $"ushort {tmpNames[0]} = 0;");
+        stringBuilder.AppendLine(indentation, $"byte {tmpNames[1]} = 0, {tmpNames[2]} = 0;");
+        stringBuilder.AppendLine(indentation, $"uint {tmpNames[3]} = 0;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"switch (reader.NextName())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Drawable", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (ushort)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Texture", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Palette", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Dlc", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[3]} = reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add(new DlcCloth({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]}, {tmpNames[3]}));");
+    }
+}

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/DlcPropConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/DlcPropConverter.cs
@@ -1,0 +1,94 @@
+using System.Text;
+using AltV.Community.MValueAdapters.Generators.Models;
+using AltV.Community.MValueAdapters.Generators.Utils;
+
+namespace AltV.Community.MValueAdapters.Generators.Converters;
+
+internal class DlcPropConverter : BaseConverter
+{
+    public override string[] AdditionalUsings() => ["AltV.Net.Data"];
+
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Drawable", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((uint)value.{propertyInfo.Name}.Drawable);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Texture", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((uint)value.{propertyInfo.Name}.Texture);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Dlc", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((uint)value.{propertyInfo.Name}.Dlc);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(3);
+
+        stringBuilder.AppendLine(indentation, $"ushort {tmpNames[0]} = 0;");
+        stringBuilder.AppendLine(indentation, $"byte {tmpNames[1]} = 0;");
+        stringBuilder.AppendLine(indentation, $"uint {tmpNames[2]} = 0;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"switch (reader.NextName())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Drawable", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (ushort)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Texture", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Dlc", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = new DlcProp({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]});");
+    }
+
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Drawable", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((uint)item.Drawable);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Texture", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((uint)item.Texture);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Dlc", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((uint)item.Dlc);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(3);
+
+        stringBuilder.AppendLine(indentation, $"ushort {tmpNames[0]} = 0;");
+        stringBuilder.AppendLine(indentation, $"byte {tmpNames[1]} = 0;");
+        stringBuilder.AppendLine(indentation, $"uint {tmpNames[2]} = 0;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"switch (reader.NextName())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Drawable", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (ushort)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Texture", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Dlc", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add(new DlcProp({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]}));");
+    }
+}

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/HeadBlendDataConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/HeadBlendDataConverter.cs
@@ -1,0 +1,152 @@
+using System.Text;
+using AltV.Community.MValueAdapters.Generators.Models;
+using AltV.Community.MValueAdapters.Generators.Utils;
+
+namespace AltV.Community.MValueAdapters.Generators.Converters;
+
+internal class HeadBlendDataConverter : BaseConverter
+{
+    public override string[] AdditionalUsings() => ["AltV.Net.Data"];
+
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("ShapeFirstID", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value(value.{propertyInfo.Name}.ShapeFirstID);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("ShapeSecondID", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value(value.{propertyInfo.Name}.ShapeSecondID);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("ShapeThirdID", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value(value.{propertyInfo.Name}.ShapeThirdID);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("SkinFirstID", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value(value.{propertyInfo.Name}.SkinFirstID);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("SkinSecondID", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value(value.{propertyInfo.Name}.SkinSecondID);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("SkinThirdID", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value(value.{propertyInfo.Name}.SkinThirdID);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("ShapeMix", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value(value.{propertyInfo.Name}.ShapeMix);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("SkinMix", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value(value.{propertyInfo.Name}.SkinMix);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("ThirdMix", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value(value.{propertyInfo.Name}.ThirdMix);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(9);
+
+        stringBuilder.AppendLine(indentation, $"uint {tmpNames[0]} = 0, {tmpNames[1]} = 0, {tmpNames[2]} = 0, {tmpNames[3]} = 0, {tmpNames[4]} = 0, {tmpNames[5]} = 0;");
+        stringBuilder.AppendLine(indentation, $"float {tmpNames[6]} = 0f, {tmpNames[7]} = 0f, {tmpNames[8]} = 0f;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"switch (reader.NextName())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("ShapeFirstID", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("ShapeSecondID", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("ShapeThirdID", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("SkinFirstID", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[3]} = reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("SkinSecondID", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[4]} = reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("SkinThirdID", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[5]} = reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("ShapeMix", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[6]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("SkinMix", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[7]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("ThirdMix", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[8]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = new HeadBlendData({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]}, {tmpNames[3]}, {tmpNames[4]}, {tmpNames[5]}, {tmpNames[6]}, {tmpNames[7]}, {tmpNames[8]});");
+    }
+
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("ShapeFirstID", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value(item.ShapeFirstID);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("ShapeSecondID", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value(item.ShapeSecondID);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("ShapeThirdID", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value(item.ShapeThirdID);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("SkinFirstID", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value(item.SkinFirstID);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("SkinSecondID", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value(item.SkinSecondID);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("SkinThirdID", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value(item.SkinThirdID);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("ShapeMix", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value(item.ShapeMix);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("SkinMix", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value(item.SkinMix);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("ThirdMix", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value(item.ThirdMix);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(9);
+
+        stringBuilder.AppendLine(indentation, $"uint {tmpNames[0]} = 0, {tmpNames[1]} = 0, {tmpNames[2]} = 0, {tmpNames[3]} = 0, {tmpNames[4]} = 0, {tmpNames[5]} = 0;");
+        stringBuilder.AppendLine(indentation, $"float {tmpNames[6]} = 0f, {tmpNames[7]} = 0f, {tmpNames[8]} = 0f;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"switch (reader.NextName())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("ShapeFirstID", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("ShapeSecondID", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("ShapeThirdID", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("SkinFirstID", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[3]} = reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("SkinSecondID", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[4]} = reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("SkinThirdID", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[5]} = reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("ShapeMix", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[6]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("SkinMix", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[7]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("ThirdMix", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[8]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add(new HeadBlendData({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]}, {tmpNames[3]}, {tmpNames[4]}, {tmpNames[5]}, {tmpNames[6]}, {tmpNames[7]}, {tmpNames[8]}));");
+    }
+}

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/HeadOverlayConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/HeadOverlayConverter.cs
@@ -1,0 +1,112 @@
+using System.Text;
+using AltV.Community.MValueAdapters.Generators.Models;
+using AltV.Community.MValueAdapters.Generators.Utils;
+
+namespace AltV.Community.MValueAdapters.Generators.Converters;
+
+internal class HeadOverlayConverter : BaseConverter
+{
+    public override string[] AdditionalUsings() => ["AltV.Net.Data"];
+
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Index", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((uint)value.{propertyInfo.Name}.Index);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Opacity", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((float)value.{propertyInfo.Name}.Opacity);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("ColorType", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((uint)value.{propertyInfo.Name}.ColorType);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("ColorIndex", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((uint)value.{propertyInfo.Name}.ColorIndex);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("SecondColorIndex", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((uint)value.{propertyInfo.Name}.SecondColorIndex);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(5);
+
+        stringBuilder.AppendLine(indentation, $"byte {tmpNames[0]} = 0, {tmpNames[2]} = 0, {tmpNames[3]} = 0, {tmpNames[4]} = 0;");
+        stringBuilder.AppendLine(indentation, $"float {tmpNames[1]} = 0f;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"switch (reader.NextName())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Index", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Opacity", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("ColorType", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("ColorIndex", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[3]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("SecondColorIndex", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[4]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = new HeadOverlay({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]}, {tmpNames[3]}, {tmpNames[4]});");
+    }
+
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Index", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((uint)item.Index);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Opacity", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)item.Opacity);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("ColorType", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((uint)item.ColorType);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("ColorIndex", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((uint)item.ColorIndex);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("SecondColorIndex", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((uint)item.SecondColorIndex);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(9);
+
+        stringBuilder.AppendLine(indentation, $"byte {tmpNames[0]} = 0, {tmpNames[2]} = 0, {tmpNames[3]} = 0, {tmpNames[4]} = 0;");
+        stringBuilder.AppendLine(indentation, $"float {tmpNames[1]} = 0f;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"switch (reader.NextName())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Index", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Opacity", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("ColorType", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("ColorIndex", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[3]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("SecondColorIndex", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[4]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add(new HeadOverlay({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]}, {tmpNames[3]}, {tmpNames[4]}));");
+    }
+}

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/PositionConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/PositionConverter.cs
@@ -1,0 +1,93 @@
+using System.Text;
+using AltV.Community.MValueAdapters.Generators.Models;
+using AltV.Community.MValueAdapters.Generators.Utils;
+
+namespace AltV.Community.MValueAdapters.Generators.Converters;
+
+internal class PositionConverter : BaseConverter
+{
+    public override string[] AdditionalUsings() => ["AltV.Net.Data"];
+
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((float)value.{propertyInfo.Name}.X);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((float)value.{propertyInfo.Name}.Y);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Z", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((float)value.{propertyInfo.Name}.Z);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(4);
+
+        stringBuilder.AppendLine(indentation, $"float {tmpNames[0]} = 0f, {tmpNames[1]} = 0f, {tmpNames[2]} = 0f;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[3]} = reader.NextName();");
+        stringBuilder.AppendLine(indentation, $"switch ({tmpNames[3]})");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Z", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = new Position({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]});");
+    }
+
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)item.X);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)item.Y);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Z", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)item.Z);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(5);
+
+        stringBuilder.AppendLine(indentation, $"float {tmpNames[0]} = 0f, {tmpNames[1]} = 0f, {tmpNames[2]} = 0f;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[3]} = reader.NextName();");
+        stringBuilder.AppendLine(indentation, $"switch ({tmpNames[3]})");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Z", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[4]} = new Position({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]});");
+        stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add({tmpNames[4]});");
+    }
+}

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/PropConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/PropConverter.cs
@@ -1,0 +1,82 @@
+using System.Text;
+using AltV.Community.MValueAdapters.Generators.Models;
+using AltV.Community.MValueAdapters.Generators.Utils;
+
+namespace AltV.Community.MValueAdapters.Generators.Converters;
+
+internal class PropConverter : BaseConverter
+{
+    public override string[] AdditionalUsings() => ["AltV.Net.Data"];
+
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Drawable", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((uint)value.{propertyInfo.Name}.Drawable);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Texture", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((uint)value.{propertyInfo.Name}.Texture);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(2);
+
+        stringBuilder.AppendLine(indentation, $"ushort {tmpNames[0]} = 0;");
+        stringBuilder.AppendLine(indentation, $"byte {tmpNames[1]} = 0;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"switch (reader.NextName())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Drawable", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (ushort)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Texture", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = new Prop({tmpNames[0]}, {tmpNames[1]});");
+    }
+
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Drawable", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((uint)item.Drawable);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Texture", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((uint)item.Texture);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(2);
+
+        stringBuilder.AppendLine(indentation, $"ushort {tmpNames[0]} = 0;");
+        stringBuilder.AppendLine(indentation, $"byte {tmpNames[1]} = 0;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"switch (reader.NextName())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Drawable", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (ushort)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Texture", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (byte)reader.NextUInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add(new Prop({tmpNames[0]}, {tmpNames[1]}));");
+    }
+}

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/QuaternionConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/QuaternionConverter.cs
@@ -12,13 +12,13 @@ internal class QuaternionConverter : BaseConverter
     {
         stringBuilder.AppendLine(indentation, "writer.BeginObject();");
         stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\");");
-        stringBuilder.AppendLine(indentation, "writer.Value((float)value.X);");
+        stringBuilder.AppendLine(indentation, $"writer.Value((float)value.{propertyInfo.Name}.X);");
         stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\");");
-        stringBuilder.AppendLine(indentation, "writer.Value((float)value.Y);");
+        stringBuilder.AppendLine(indentation, $"writer.Value((float)value.{propertyInfo.Name}.Y);");
         stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Z", classInfo.NamingConvention)}\");");
-        stringBuilder.AppendLine(indentation, "writer.Value((float)value.Z);");
+        stringBuilder.AppendLine(indentation, $"writer.Value((float)value.{propertyInfo.Name}.Z);");
         stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("W", classInfo.NamingConvention)}\");");
-        stringBuilder.AppendLine(indentation, "writer.Value((float)value.W);");
+        stringBuilder.AppendLine(indentation, $"writer.Value((float)value.{propertyInfo.Name}.W);");
         stringBuilder.AppendLine(indentation, "writer.EndObject();");
     }
 

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/QuaternionConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/QuaternionConverter.cs
@@ -1,0 +1,103 @@
+using System.Text;
+using AltV.Community.MValueAdapters.Generators.Models;
+using AltV.Community.MValueAdapters.Generators.Utils;
+
+namespace AltV.Community.MValueAdapters.Generators.Converters;
+
+internal class QuaternionConverter : BaseConverter
+{
+    public override string[] AdditionalUsings() => ["System.Numerics"];
+
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)value.X);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)value.Y);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Z", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)value.Z);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("W", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)value.W);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(5);
+
+        stringBuilder.AppendLine(indentation, $"float {tmpNames[0]} = 0f, {tmpNames[1]} = 0f, {tmpNames[2]} = 0f, {tmpNames[3]} = 0f;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[4]} = reader.NextName();");
+        stringBuilder.AppendLine(indentation, $"switch ({tmpNames[4]})");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Z", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("W", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[3]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = new Quaternion({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]}, {tmpNames[3]});");
+    }
+
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)item.X);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)item.Y);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Z", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)item.Z);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("W", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)item.W);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(6);
+
+        stringBuilder.AppendLine(indentation, $"float {tmpNames[0]} = 0f, {tmpNames[1]} = 0f, {tmpNames[2]} = 0f, {tmpNames[3]} = 0f;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[4]} = reader.NextName();");
+        stringBuilder.AppendLine(indentation, $"switch ({tmpNames[4]})");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Z", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("W", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[3]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[5]} = new Quaternion({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]}, {tmpNames[3]});");
+        stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add({tmpNames[5]});");
+    }
+}

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/RgbaConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/RgbaConverter.cs
@@ -1,0 +1,103 @@
+using System.Text;
+using AltV.Community.MValueAdapters.Generators.Models;
+using AltV.Community.MValueAdapters.Generators.Utils;
+
+namespace AltV.Community.MValueAdapters.Generators.Converters;
+
+internal class RgbaConverter : BaseConverter
+{
+    public override string[] AdditionalUsings() => ["AltV.Net.Data"];
+
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("R", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((int)value.{propertyInfo.Name}.R);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("G", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((int)value.{propertyInfo.Name}.G);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("B", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((int)value.{propertyInfo.Name}.B);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("A", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((int)value.{propertyInfo.Name}.A);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(5);
+
+        stringBuilder.AppendLine(indentation, $"byte {tmpNames[0]} = 0, {tmpNames[1]} = 0, {tmpNames[2]} = 0, {tmpNames[3]} = 0;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[4]} = reader.NextName();");
+        stringBuilder.AppendLine(indentation, $"switch ({tmpNames[4]})");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("R", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (byte)reader.NextInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("G", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (byte)reader.NextInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("B", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = (byte)reader.NextInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("A", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[3]} = (byte)reader.NextInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = new Rgba({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]}, {tmpNames[3]});");
+    }
+
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("R", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((int)item.R);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("G", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((int)item.G);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("B", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((int)item.B);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("A", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((int)item.A);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(6);
+
+        stringBuilder.AppendLine(indentation, $"byte {tmpNames[0]} = 0, {tmpNames[1]} = 0, {tmpNames[2]} = 0, {tmpNames[3]} = 0;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[4]} = reader.NextName();");
+        stringBuilder.AppendLine(indentation, $"switch ({tmpNames[4]})");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("R", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (byte)reader.NextInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("G", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (byte)reader.NextInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("B", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = (byte)reader.NextInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("A", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[3]} = (byte)reader.NextInt();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[5]} = new Rgba({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]}, {tmpNames[3]});");
+        stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add({tmpNames[5]});");
+    }
+}

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/RotationConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/RotationConverter.cs
@@ -1,0 +1,93 @@
+using System.Text;
+using AltV.Community.MValueAdapters.Generators.Models;
+using AltV.Community.MValueAdapters.Generators.Utils;
+
+namespace AltV.Community.MValueAdapters.Generators.Converters;
+
+internal class RotationConverter : BaseConverter
+{
+    public override string[] AdditionalUsings() => ["AltV.Net.Data"];
+
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Roll", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((float)value.{propertyInfo.Name}.Roll);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Pitch", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((float)value.{propertyInfo.Name}.Pitch);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Yaw", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, $"writer.Value((float)value.{propertyInfo.Name}.Yaw);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(4);
+
+        stringBuilder.AppendLine(indentation, $"float {tmpNames[0]} = 0f, {tmpNames[1]} = 0f, {tmpNames[2]} = 0f;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[3]} = reader.NextName();");
+        stringBuilder.AppendLine(indentation, $"switch ({tmpNames[3]})");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Roll", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Pitch", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Yaw", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = new Rotation({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]});");
+    }
+
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Roll", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)item.Roll);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Pitch", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)item.Pitch);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Yaw", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)item.Yaw);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(5);
+
+        stringBuilder.AppendLine(indentation, $"float {tmpNames[0]} = 0f, {tmpNames[1]} = 0f, {tmpNames[2]} = 0f;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[3]} = reader.NextName();");
+        stringBuilder.AppendLine(indentation, $"switch ({tmpNames[3]})");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Roll", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Pitch", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Yaw", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[4]} = new Rotation({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]});");
+        stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add({tmpNames[4]});");
+    }
+}

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/Vector2Converter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/Vector2Converter.cs
@@ -1,0 +1,84 @@
+using System.Text;
+using AltV.Community.MValueAdapters.Generators.Abstractions;
+using AltV.Community.MValueAdapters.Generators.Models;
+using AltV.Community.MValueAdapters.Generators.Utils;
+
+namespace AltV.Community.MValueAdapters.Generators.Converters;
+
+internal class Vector2Converter : BaseConverter
+{
+    public override string[] AdditionalUsings() => ["System.Numerics"];
+    
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)value.X);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)value.Y);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(3);
+
+        stringBuilder.AppendLine(indentation, $"float {tmpNames[0]} = 0f, {tmpNames[1]} = 0f;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[2]} = reader.NextName();");
+        stringBuilder.AppendLine(indentation, $"switch ({tmpNames[2]})");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = new Vector2({tmpNames[0]}, {tmpNames[1]});");
+    }
+
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)item.X);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)item.Y);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(4);
+
+        stringBuilder.AppendLine(indentation, $"float {tmpNames[0]} = 0f, {tmpNames[1]} = 0f;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[2]} = reader.NextName();");
+        stringBuilder.AppendLine(indentation, $"switch ({tmpNames[2]})");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[3]} = new Vector2({tmpNames[0]}, {tmpNames[1]});");
+        stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add({tmpNames[3]});");
+    }
+}

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/Vector2Converter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/Vector2Converter.cs
@@ -8,14 +8,14 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 internal class Vector2Converter : BaseConverter
 {
     public override string[] AdditionalUsings() => ["System.Numerics"];
-    
+
     protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, "writer.BeginObject();");
         stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\");");
-        stringBuilder.AppendLine(indentation, "writer.Value((float)value.X);");
+        stringBuilder.AppendLine(indentation, $"writer.Value((float)value.{propertyInfo.Name}.X);");
         stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\");");
-        stringBuilder.AppendLine(indentation, "writer.Value((float)value.Y);");
+        stringBuilder.AppendLine(indentation, $"writer.Value((float)value.{propertyInfo.Name}.Y);");
         stringBuilder.AppendLine(indentation, "writer.EndObject();");
     }
 

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/Vector3Converter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/Vector3Converter.cs
@@ -7,16 +7,16 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 internal class Vector3Converter : BaseConverter
 {
     public override string[] AdditionalUsings() => ["System.Numerics"];
-    
+
     protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, "writer.BeginObject();");
         stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\");");
-        stringBuilder.AppendLine(indentation, "writer.Value((float)value.X);");
+        stringBuilder.AppendLine(indentation, $"writer.Value((float)value.{propertyInfo.Name}.X);");
         stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\");");
-        stringBuilder.AppendLine(indentation, "writer.Value((float)value.Y);");
+        stringBuilder.AppendLine(indentation, $"writer.Value((float)value.{propertyInfo.Name}.Y);");
         stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Z", classInfo.NamingConvention)}\");");
-        stringBuilder.AppendLine(indentation, "writer.Value((float)value.Z);");
+        stringBuilder.AppendLine(indentation, $"writer.Value((float)value.{propertyInfo.Name}.Z);");
         stringBuilder.AppendLine(indentation, "writer.EndObject();");
     }
 

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/Vector3Converter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/Vector3Converter.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using AltV.Community.MValueAdapters.Generators.Abstractions;
 using AltV.Community.MValueAdapters.Generators.Models;
 using AltV.Community.MValueAdapters.Generators.Utils;
 
@@ -7,6 +6,8 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal class Vector3Converter : BaseConverter
 {
+    public override string[] AdditionalUsings() => ["System.Numerics"];
+    
     protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, "writer.BeginObject();");

--- a/AltV.Community.MValueAdapters.Generators/Converters/Other/Vector3Converter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Other/Vector3Converter.cs
@@ -1,0 +1,92 @@
+using System.Text;
+using AltV.Community.MValueAdapters.Generators.Abstractions;
+using AltV.Community.MValueAdapters.Generators.Models;
+using AltV.Community.MValueAdapters.Generators.Utils;
+
+namespace AltV.Community.MValueAdapters.Generators.Converters;
+
+internal class Vector3Converter : BaseConverter
+{
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)value.X);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)value.Y);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Z", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)value.Z);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(4);
+
+        stringBuilder.AppendLine(indentation, $"float {tmpNames[0]} = 0f, {tmpNames[1]} = 0f, {tmpNames[2]} = 0f;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[3]} = reader.NextName();");
+        stringBuilder.AppendLine(indentation, $"switch ({tmpNames[3]})");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Z", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = new Vector3({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]});");
+    }
+
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        stringBuilder.AppendLine(indentation, "writer.BeginObject();");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)item.X);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)item.Y);");
+        stringBuilder.AppendLine(indentation, $"writer.Name(\"{NamingConventionHelpers.GetName("Z", classInfo.NamingConvention)}\");");
+        stringBuilder.AppendLine(indentation, "writer.Value((float)item.Z);");
+        stringBuilder.AppendLine(indentation, "writer.EndObject();");
+    }
+
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
+    {
+        var tmpNames = NameRandomizer.Get(5);
+
+        stringBuilder.AppendLine(indentation, $"float {tmpNames[0]} = 0f, {tmpNames[1]} = 0f, {tmpNames[2]} = 0f;");
+        stringBuilder.AppendLine(indentation, "reader.BeginObject();");
+        stringBuilder.AppendLine(indentation, "while (reader.HasNext())");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[3]} = reader.NextName();");
+        stringBuilder.AppendLine(indentation, $"switch ({tmpNames[3]})");
+        stringBuilder.AppendLine(indentation++, "{");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("X", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[0]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Y", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[1]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, $"case \"{NamingConventionHelpers.GetName("Z", classInfo.NamingConvention)}\":");
+        stringBuilder.AppendLine(indentation, $"{tmpNames[2]} = (float)reader.NextDouble();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation++, "default:");
+        stringBuilder.AppendLine(indentation, "reader.SkipValue();");
+        stringBuilder.AppendLine(indentation--, "continue;");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation--, "}");
+        stringBuilder.AppendLine(indentation, "reader.EndObject();");
+        stringBuilder.AppendLine(indentation, $"var {tmpNames[4]} = new Vector3({tmpNames[0]}, {tmpNames[1]}, {tmpNames[2]});");
+        stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add({tmpNames[4]});");
+    }
+}

--- a/AltV.Community.MValueAdapters.Generators/Converters/Text/CharConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Text/CharConverter.cs
@@ -5,22 +5,22 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal class CharConverter : BaseConverter
 {
-    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"writer.Value(value.{propertyInfo.Name}.ToString());");
     }
 
-    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = reader.NextString().FirstOrDefault();");
     }
 
-    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, "writer.Value(item.ToString());");
     }
 
-    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add(reader.NextString().FirstOrDefault());");
     }

--- a/AltV.Community.MValueAdapters.Generators/Converters/Text/StringConverter.cs
+++ b/AltV.Community.MValueAdapters.Generators/Converters/Text/StringConverter.cs
@@ -5,22 +5,22 @@ namespace AltV.Community.MValueAdapters.Generators.Converters;
 
 internal class StringConverter : BaseConverter
 {
-    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"writer.Value(value.{propertyInfo.Name});");
     }
 
-    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateItemReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"c.{propertyInfo.Name} = reader.NextString();");
     }
 
-    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionWriteCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, "writer.Value(item);");
     }
 
-    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValuePropertyInfo propertyInfo)
+    protected override void GenerateCollectionReadCode(StringBuilder stringBuilder, ref int indentation, MValueClassInfo classInfo, MValuePropertyInfo propertyInfo)
     {
         stringBuilder.AppendLine(indentation, $"{propertyInfo.Name}Builder.Add(reader.NextString());");
     }

--- a/AltV.Community.MValueAdapters.Generators/MValueAdapterGenerator.cs
+++ b/AltV.Community.MValueAdapters.Generators/MValueAdapterGenerator.cs
@@ -50,6 +50,16 @@ public class MValueAdapterGenerator : IIncrementalGenerator
             { "Vector2", new Vector2Converter() },
             { "Vector3", new Vector3Converter() },
             { "Quaternion", new QuaternionConverter() },
+            // AltV.Net.Data
+            { "Position", new PositionConverter() },
+            { "Rotation", new RotationConverter() },
+            { "Rgba", new RgbaConverter() },
+            { "Cloth", new ClothConverter() },
+            { "DlcCloth", new DlcClothConverter() },
+            { "Prop", new PropConverter() },
+            { "DlcProp", new DlcPropConverter() },
+            { "HeadBlendData", new HeadBlendDataConverter() },
+            { "HeadOverlay", new HeadOverlayConverter() },
         };
     }
 

--- a/AltV.Community.MValueAdapters.Generators/MValueAdapterGenerator.cs
+++ b/AltV.Community.MValueAdapters.Generators/MValueAdapterGenerator.cs
@@ -286,7 +286,7 @@ public class MValueAdapterGenerator : IIncrementalGenerator
                 SourceText.From(
                     string.Format(
                         Templates.ConverterTemplate,
-                        string.Join("\n", additionalUsings.Select(ns => $"using {ns};")),
+                        string.Join("\n", additionalUsings.Distinct().Select(ns => $"using {ns};")),
                         classInfo.Name,
                         readerCode,
                         writerCode

--- a/AltV.Community.MValueAdapters.Generators/Models/MValueClassInfo.cs
+++ b/AltV.Community.MValueAdapters.Generators/Models/MValueClassInfo.cs
@@ -8,7 +8,7 @@ internal class MValueClassInfo
     internal readonly string Namespace;
     internal readonly MValuePropertyInfo[] PropertyInfos;
     internal readonly NamingConvention NamingConvention;
-    
+
     internal MValueClassInfo(string name, string @namespace, MValuePropertyInfo[] propertyInfos, NamingConvention namingConvention)
     {
         Name = name;

--- a/AltV.Community.MValueAdapters.Generators/Models/MValueClassInfo.cs
+++ b/AltV.Community.MValueAdapters.Generators/Models/MValueClassInfo.cs
@@ -1,15 +1,19 @@
-﻿namespace AltV.Community.MValueAdapters.Generators.Models;
+﻿using AltV.Community.MValueAdapters.Generators.Abstractions;
+
+namespace AltV.Community.MValueAdapters.Generators.Models;
 
 internal class MValueClassInfo
 {
     internal readonly string Name;
     internal readonly string Namespace;
     internal readonly MValuePropertyInfo[] PropertyInfos;
-
-    internal MValueClassInfo(string name, string @namespace, MValuePropertyInfo[] propertyInfos)
+    internal readonly NamingConvention NamingConvention;
+    
+    internal MValueClassInfo(string name, string @namespace, MValuePropertyInfo[] propertyInfos, NamingConvention namingConvention)
     {
         Name = name;
         Namespace = @namespace;
         PropertyInfos = propertyInfos;
+        NamingConvention = namingConvention;
     }
 }

--- a/AltV.Community.MValueAdapters.Generators/Models/NamingConventionHelpers.cs
+++ b/AltV.Community.MValueAdapters.Generators/Models/NamingConventionHelpers.cs
@@ -1,9 +1,24 @@
+using System;
 using System.Text;
+using AltV.Community.MValueAdapters.Generators.Abstractions;
 
 namespace AltV.Community.MValueAdapters.Generators.Models;
 
 internal class NamingConventionHelpers
 {
+    public static string GetName(string source, NamingConvention namingConvention)
+    {
+        return namingConvention switch
+        {
+            NamingConvention.UsePropertyName => source,
+            NamingConvention.UpperCase => source.ToUpper(),
+            NamingConvention.LowerCase => source.ToLower(),
+            NamingConvention.PascalCase => ToPascalCase(source),
+            NamingConvention.CamelCase => ToCamelCase(source),
+            _ => throw new InvalidOperationException("Used naming convention is not valid")
+        };
+    }
+    
     public static string ToUpper(string name)
     {
         return name.ToUpper();

--- a/AltV.Community.MValueAdapters.Generators/Models/StringBuilderExtensions.cs
+++ b/AltV.Community.MValueAdapters.Generators/Models/StringBuilderExtensions.cs
@@ -5,7 +5,7 @@ internal static class StringBuilderExtensions
 {
     internal static void AppendLine(this StringBuilder sb, int indentation, string text)
     {
-        var line = $"{new string('\t', indentation)}{text}";
+        var line = $"{new string(' ', indentation * 4)}{text}";
         sb.AppendLine(line);
     }
 }

--- a/AltV.Community.MValueAdapters.Generators/Utils/NameRandomizer.cs
+++ b/AltV.Community.MValueAdapters.Generators/Utils/NameRandomizer.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+
+namespace AltV.Community.MValueAdapters.Generators.Utils;
+
+public static class NameRandomizer
+{
+    public static string Get()
+    {
+        string guid;
+        
+        do guid = Guid.NewGuid().ToString().Replace("-", "");
+        while (char.IsDigit(guid[0]) || _usedNames.Contains(guid));
+
+        _usedNames.Add(guid);
+        
+        return guid;
+    }
+
+    public static string[] Get(int count)
+    {
+        var propertyNames = new string[count];
+        for (var i = 0; i < count; i++) propertyNames[i] = Get();
+        return propertyNames;
+    }
+
+    private static HashSet<string> _usedNames = [];
+}

--- a/AltV.Community.MValueAdapters.Generators/Utils/NameRandomizer.cs
+++ b/AltV.Community.MValueAdapters.Generators/Utils/NameRandomizer.cs
@@ -8,13 +8,12 @@ public static class NameRandomizer
     public static string Get()
     {
         string guid;
-        
+
         do guid = Guid.NewGuid().ToString().Replace("-", "");
-        while (char.IsDigit(guid[0]) || _usedNames.Contains(guid));
+        while (_usedNames.Contains(guid));
 
         _usedNames.Add(guid);
-        
-        return guid;
+        return '_' + guid;
     }
 
     public static string[] Get(int count)
@@ -24,5 +23,5 @@ public static class NameRandomizer
         return propertyNames;
     }
 
-    private static HashSet<string> _usedNames = [];
+    private static readonly HashSet<string> _usedNames = [];
 }


### PR DESCRIPTION
I recommend to merge it into a new branch, because I'm not able to test the changes right now and they could potentially be breaking

- [X] Vector2 converter
- [X] Vector3 converter
- [X] Quaternion converter
- [X] Added a name generator for variables - Utils/NameRandomizer.cs (1)
- [X] Added "AdditionalUsings" to adapters (2)
- [X] Added naming convention info to MValueClassInfo (3)
- [X] Outsourced GetPropertyName to NamingConventionHelper (3)

(1) Will generate guids until they start with a letter and aren't used yet (managed via HashSet). Required for e.g. multiple vector3 which would else all use `float x, y, z` in the code
(2) Converters can provide additional usings, so e.g. Vector3 can add System.Numerics to the generated file
(3) Required to adjust properties from Vectors & Quaternions to they will be compatible with JS 