### PR TITLE
Fix templates that use core

### DIFF
--- a/AltV.Community.MValueAdapters.Generators/Constants/Templates.cs
+++ b/AltV.Community.MValueAdapters.Generators/Constants/Templates.cs
@@ -84,9 +84,9 @@ public static class AltExtensions
 }}
 ";
 
-    internal const string AdapterTemplate = "\t\tAltV.Net.Shared.AltShared.Core.RegisterMValueAdapter(new {0}Adapter());";
+    internal const string AdapterTemplate = "\t\tAltV.Net.Alt.RegisterMValueAdapter(new {0}Adapter());";
 
-    internal const string ListAdapterTemplate = "\t\t\tAltV.Net.Shared.AltShared.Core.RegisterMValueAdapter(Elements.Args.DefaultMValueAdapters.GetArrayAdapter(new {0}Adapter()));";
+    internal const string ListAdapterTemplate = "\t\t\tAltV.Net.Alt.RegisterMValueAdapter(Elements.Args.DefaultMValueAdapters.GetArrayAdapter(new {0}Adapter()));";
 
-    internal const string LogAdapterTemplate = "\t\t\tAltV.Net.Shared.AltShared.Core.LogInfo($\"Registered MValueAdapter: {0}\");";
+    internal const string LogAdapterTemplate = "\t\t\tAltV.Net.Alt.LogInfo($\"Registered MValueAdapter: {0}\");";
 }


### PR DESCRIPTION
alt:V recently started removing the "core" so this nuget will break on the release.

I got told that u dont need to use shared and in alt there is a method to register them so i adjusted it.

Message from team:
https://discord.com/channels/371265202378899476/1281276477517860957/1285601364977647747